### PR TITLE
Fix build script for Windows client.

### DIFF
--- a/client/build_x86_x64_together.py
+++ b/client/build_x86_x64_together.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     config +='\tEndGlobalSection'
     configRE = re.compile(r'\tGlobalSection\(SolutionConfigurationPlatforms\) = preSolution.+?\tEndGlobalSection', re.S)
     content = configRE.sub(CONFIGS, content)
-    configPostRE = re.compile(r'\tGlobalSection\(SolutionConfigurationPlatforms\) = postSolution.+?\tEndGlobalSection', re.S)
+    configPostRE = re.compile(r'\tGlobalSection\(ProjectConfigurationPlatforms\) = postSolution.+?\tEndGlobalSection', re.S)
     content = configPostRE.sub(config, content)
     file = open('all.sln', 'w')
     file.write(content)


### PR DESCRIPTION
Hi, I'm Chen Gong <chengong@google.com> from IME team, working on the client input method framework.

Commit https://github.com/lotem/google-input-tools/commit/1d5a10197c180587e7b851125982eb3bdd7edad2 fixed a bug in a script modifying all.sln file for mixed-platform (x86 & x64) builds.
Without this fix, the solution works well in the MSVS IDE, but fails to do a release build with msbuild.exe on the console.