### PR TITLE
client: add an optional field for inline composition text in the message.

### DIFF
--- a/client/components/win_frontend/frontend_component.h
+++ b/client/components/win_frontend/frontend_component.h
@@ -109,8 +109,6 @@ class FrontendComponent : public EngineInterface,
   // Gets value from settings store, if failed, set int_value to default value.
   void GetIntegerValue(std::string key, int32* int_value);
 
-  void AssembleComposition();
-  bool ShouldAssembleComposition() const;
   void OnIPCDisconnected();
   void CacheMessage(ipc::proto::Message* message);
   void SwitchInputMethod();
@@ -133,7 +131,6 @@ class FrontendComponent : public EngineInterface,
   int caret_;
   std::wstring composition_in_window_;
   int caret_in_window_;
-  bool was_backspace_;
 
   // Legacy variable from engine.cc, used to prevent EndComposition from
   // being re-entrant.

--- a/client/ipc/protos/ipc.protodevel
+++ b/client/ipc/protos/ipc.protodevel
@@ -505,6 +505,13 @@ message Composition {
   // encoding, in order to simplify code for Windows and Mac, indexes stored in
   // |selection| are number of UTF-16 code points
   optional Range selection = 2;
+
+  // The text displayed inline, if supported by the frontend.
+  // Typically this is the resulting text if we were to commit the composition.
+  optional Text inline_text = 3;
+
+  // The selection range for |inline_text| .
+  optional Range inline_selection = 4;
 }
 
 // A message to represent a keyboard event.


### PR DESCRIPTION
replacing the `AssembleComposition()` logic.

@synch9 and haicsun please help review this CL.
I want to argue that this logic be handled by the engine rather than the frontend.

Formerly: inline composition text = part of composition.text + the active candidate.
However, I suspect that the (re)assembling wasn't done in response to some messages, eg. MSG_SELECTED_CANDIDATE_CHANGED