### PR TITLE
Fix off by ones when parsing XML comments

### DIFF
--- a/client/third_party/google_gadgets_for_linux/extensions/libxml2_xml_parser/libxml2_xml_parser.cc
+++ b/client/third_party/google_gadgets_for_linux/extensions/libxml2_xml_parser/libxml2_xml_parser.cc
@@ -470,7 +470,7 @@ std::string GetHTMLCharset(const char* html_content) {
     if (!cursor)
       break;
 
-    if (strncmp(cursor, "<!--", 3) == 0) {
+    if (strncmp(cursor, "<!--", 4) == 0) {
       cursor = strstr(cursor, "-->");
       if (!cursor)
         break;

--- a/client/third_party/google_gadgets_for_linux/ggadget/win32/xml_parser.cc
+++ b/client/third_party/google_gadgets_for_linux/ggadget/win32/xml_parser.cc
@@ -447,7 +447,7 @@ std::string GetHTMLCharset(const char* html_content) {
     if (!cursor)
       break;
 
-    if (strncmp(cursor, "<!--", 3) == 0) {
+    if (strncmp(cursor, "<!--", 4) == 0) {
       cursor = strstr(cursor, "-->");
       if (!cursor)
         break;


### PR DESCRIPTION
This commit fixes off by ones when parsing XML comments.

The `strncmp` calls before this commit: strncmp(cursor, "<!--", 3) would also incorrectly match shorter strings such as "<!-". Depending on the use-cases this might or might not be vulnerabilities.

This could be a security bug/risk for the
callers of this library, e.g. if two different XML parsing libraries
would be used, e.g., for validating and then executing some policies. I would
even say this could cause bugs similar to
https://twitter.com/s1guza/status/1255641164885131268 to happen.

This issue was first reported to Google on Apr 13, 2020 via
https://www.google.com/appserve/security-bugs/ but I was replied with
"We think the issue might not be severe enough for us to track it as a
security bug", so I am sending a fix here.